### PR TITLE
Removing rest_gathering 1 week limitation.

### DIFF
--- a/scripts/rest_gathering.py
+++ b/scripts/rest_gathering.py
@@ -25,10 +25,6 @@ def date_check(since, until):
         sys.stdout.write("'since' parameter cannot be newer than 'until'.\nQuitting...")
         sys.exit(0)
 
-    elif until < (now - datetime.timedelta(days = 8)):
-        sys.stdout.write("'until' parameter cannot be older than 7 days as per Twitter API regulations.\nQuitting...")
-        sys.exit(0)
-
 def main():
     args = add_args()
     client = tweepy.Client(args.key, wait_on_rate_limit=True)


### PR DESCRIPTION
Since, academic tier API doesn't have this limitation at the moment, this limitation needs to be removed from the code.